### PR TITLE
Fixed ST2 errors

### DIFF
--- a/MultiEditUtils.py
+++ b/MultiEditUtils.py
@@ -78,7 +78,8 @@ class NormalizeRegionEndsCommand(sublime_plugin.TextCommand):
 			regions = self.normalizeRegions(selection)
 
 		selection.clear()
-		selection.add_all(regions)
+		for region in regions:
+			selection.add(region)
 
 
 	def normalizeRegions(self, regions):
@@ -91,10 +92,11 @@ class NormalizeRegionEndsCommand(sublime_plugin.TextCommand):
 		invertedRegions = []
 
 		for region in regions:
+			invertedRegion = region
 			if condition(region):
-				[region.a, region.b] = [region.b, region.a]
+				invertedRegion = sublime.Region(region.b, region.a)
 
-			invertedRegions.append(region)
+			invertedRegions.append(invertedRegion)
 
 		return invertedRegions
 
@@ -140,7 +142,8 @@ class SplitSelectionCommand(sublime_plugin.TextCommand):
 
 		selection = self.view.sel()
 		selection.clear()
-		selection.add_all(self.savedSelection)
+		for region in self.savedSelection:
+			selection.add(region)
 
 		self.workaroundForRefreshBug(self, self.view, selection)
 
@@ -170,7 +173,8 @@ class SplitSelectionCommand(sublime_plugin.TextCommand):
 
 		selection = view.sel()
 		selection.clear()
-		selection.add_all(newRegions)
+		for region in newRegions:
+			selection.add(region)
 
 		self.workaroundForRefreshBug(view, selection)
 


### PR DESCRIPTION
As discussed in #2, Sublime Text 2 would be appreciated. This PR revisits and fixes up issues that ST2 was having. In this PR:
- Move from `add_all` to `for + add` to add lists of regions
  - ST2 only supports `RegionSet's` for `add_all` which ironically cannot be instantiated in Python
  - http://www.sublimetext.com/docs/2/api_reference.html#sublime.RegionSet
- Moved to `Region` constructor for inverting regions
  - ST2 did not like setting `a` and `b` properties of an existing region (I guess they are immutable)
  - http://www.sublimetext.com/docs/2/api_reference.html#sublime.Region

/cc @philippotto
