### PR TITLE
Fix exception when selection is bigger than visible region

### DIFF
--- a/MultiEditUtils.py
+++ b/MultiEditUtils.py
@@ -96,7 +96,7 @@ class NormalizeRegionEndsCommand(sublime_plugin.TextCommand):
 		visibleRegion = self.view.visible_region()
 
 		for index, region in enumerate(self.view.sel()):
-			if visibleRegion.a <= region.b and region.b <= visibleRegion.b:
+			if region.intersects(visibleRegion):
 				return index
 
 


### PR DESCRIPTION
If there is a region in the selection that is currently visible but is
larger than the visible region, an exception is thrown when trying
to normalize selections. This commit changes
findFirstVisibleRegionIndex to use the Region.intersects method to
accurately determine what the first visible region is.
