### PR TITLE
Selections as Fields

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -10,5 +10,51 @@
       {"key": "setting.is_widget", "operator": "equal", "operand": false}
     ]
   },
-  { "keys": ["ctrl+alt+f"], "command": "multi_find_all" }
+  { "keys": ["ctrl+alt+f"], "command": "multi_find_all" },
+  { "keys": ["ctrl+alt+d"], "command": "selection_fields", "args": {"mode": "smart"} },
+  { "keys": ["escape"], "command": "selection_fields",
+    "args": {"mode": "pop"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_escape_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_next_field", "operator": "equal", "operand": false },
+      { "key": "has_prev_field", "operator": "equal", "operand": false },
+      { "key": "panel_visible", "operator": "equal", "operand": false },
+      { "key": "overlay_visible", "operator": "equal", "operand": false },
+      // usually we would use popup_visible, but this is ST3 only
+      { "key": "meu_popup_visible_proxy", "operator": "equal", "operand": false },
+      { "key": "auto_complete_visible", "operator": "equal", "operand": false }
+    ]
+  },
+  { "keys": ["shift+escape"], "command": "selection_fields",
+    "args": {"mode": "remove"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_escape_enabled" }
+    ]
+  },
+  { "keys": ["tab"], "command": "selection_fields",
+    "args": {"mode": "smart"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_tab_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_next_field", "operator": "equal", "operand": false },
+      { "key": "auto_complete_visible", "operator": "equal", "operand": false }
+    ]
+  },
+  { "keys": ["shift+tab"], "command": "selection_fields",
+    "args": {"mode": "cycle", "jump_forward": false },
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_tab_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_prev_field", "operator": "equal", "operand": false }
+    ]
+  }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -10,5 +10,51 @@
       {"key": "setting.is_widget", "operator": "equal", "operand": false}
     ]
   },
-  { "keys": ["super+alt+j"], "command": "multi_find_all" }
+  { "keys": ["super+alt+j"], "command": "multi_find_all" },
+  { "keys": ["super+alt+d"], "command": "selection_fields", "args": {"mode": "smart"} },
+  { "keys": ["escape"], "command": "selection_fields",
+    "args": {"mode": "pop"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_escape_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_next_field", "operator": "equal", "operand": false },
+      { "key": "has_prev_field", "operator": "equal", "operand": false },
+      { "key": "panel_visible", "operator": "equal", "operand": false },
+      { "key": "overlay_visible", "operator": "equal", "operand": false },
+      // usually we would use popup_visible, but this is ST3 only
+      { "key": "meu_popup_visible_proxy", "operator": "equal", "operand": false },
+      { "key": "auto_complete_visible", "operator": "equal", "operand": false }
+    ]
+  },
+  { "keys": ["shift+escape"], "command": "selection_fields",
+    "args": {"mode": "remove"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_escape_enabled" }
+    ]
+  },
+  { "keys": ["tab"], "command": "selection_fields",
+    "args": {"mode": "smart"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_tab_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_next_field", "operator": "equal", "operand": false },
+      { "key": "auto_complete_visible", "operator": "equal", "operand": false }
+    ]
+  },
+  { "keys": ["shift+tab"], "command": "selection_fields",
+    "args": {"mode": "cycle", "jump_forward": false },
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_tab_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_prev_field", "operator": "equal", "operand": false }
+    ]
+  }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -10,5 +10,51 @@
       {"key": "setting.is_widget", "operator": "equal", "operand": false}
     ]
   },
-  { "keys": ["ctrl+alt+f"], "command": "multi_find_all" }
+  { "keys": ["ctrl+alt+f"], "command": "multi_find_all" },
+  { "keys": ["ctrl+alt+d"], "command": "selection_fields", "args": {"mode": "smart"} },
+  { "keys": ["escape"], "command": "selection_fields",
+    "args": {"mode": "pop"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_escape_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_next_field", "operator": "equal", "operand": false },
+      { "key": "has_prev_field", "operator": "equal", "operand": false },
+      { "key": "panel_visible", "operator": "equal", "operand": false },
+      { "key": "overlay_visible", "operator": "equal", "operand": false },
+      // usually we would use popup_visible, but this is ST3 only
+      { "key": "meu_popup_visible_proxy", "operator": "equal", "operand": false },
+      { "key": "auto_complete_visible", "operator": "equal", "operand": false }
+    ]
+  },
+  { "keys": ["shift+escape"], "command": "selection_fields",
+    "args": {"mode": "remove"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_escape_enabled" }
+    ]
+  },
+  { "keys": ["tab"], "command": "selection_fields",
+    "args": {"mode": "smart"},
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_tab_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_next_field", "operator": "equal", "operand": false },
+      { "key": "auto_complete_visible", "operator": "equal", "operand": false }
+    ]
+  },
+  { "keys": ["shift+tab"], "command": "selection_fields",
+    "args": {"mode": "cycle", "jump_forward": false },
+    "context":
+    [
+      { "key": "is_selection_field" },
+      { "key": "selection_fields_tab_enabled" },
+      // set the default precedence to be less than snippet fields
+      { "key": "has_prev_field", "operator": "equal", "operand": false }
+    ]
+  }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,7 @@
 [
   { "command": "jump_to_last_region", "caption" : "MultiEditUtils: Jump to last region" },
   { "command": "add_last_selection", "caption" : "MultiEditUtils: Add last selection" },
+  { "command": "selection_fields", "caption": "MultiEditUtils: Selection as Fields", "args": {"mode": "toggle"} },
   { "command": "cycle_through_regions", "caption" : "MultiEditUtils: Cycle through regions" },
   { "command": "normalize_region_ends", "caption" : "MultiEditUtils: Normalize region ends" },
   { "command": "split_selection", "caption" : "MultiEditUtils: Split selection" },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -14,6 +14,7 @@
           { "command": "strip_selection"},
           { "command": "remove_empty_regions"},
           { "command": "multi_find_all"},
+          { "command": "selection_fields", "caption": "Selection as Fields", "args": {"mode": "toggle"} },
           { "command": "preserve_case"}
         ]
       }

--- a/MultiEditUtils.sublime-settings
+++ b/MultiEditUtils.sublime-settings
@@ -1,3 +1,7 @@
 {
-  "live_split_selection" : true
+  "live_split_selection" : true,
+  // whether the tab key should jump to the next field during the selection field mode
+  "selection_fields_tab_enabled": true,
+  // whether the escape key should cancel the selection field mode
+  "selection_fields_escape_enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,46 @@ Similar to the built-in "Quick Find All" functionality, MultiEditUtils provides 
 ![](http://philippotto.github.io/Sublime-MultiEditUtils/screens/08%20multi%20find%20all.gif)
 
 
+### Use selections as fields
+
+Converts the selections to fields similar to the fields used in snippets. When the `selection_fields` command is executed, all current selections are saved as fields, which can be activated one by one. The first field is activated automatically. You can jump to the next field with **tab** (or the default keybinding) and to the previous field with **shift+tab**. If you jump behind the last field or press **escape** all fields will be converted to proper selections again. If you press **shift+escape** all fields will be removed and the current selection remains unchanged.
+
+![demo_selection_fields](https://cloud.githubusercontent.com/assets/12573621/14402686/17391716-fe3d-11e5-8fba-4e52a4f93459.gif)
+
+You can bind this command to a keybinding by adding the following to your keymap (Change the key to the keybinding you prefer):
+
+``` js
+{ "keys": ["alt+d"], "command": "selection_fields" },
+```
+
+Although using one keybinding with the default options should be sufficient for most cases, additional modes and arguments are possible. Feel free to ignore or use them as you wish.
+
+Arguments:
+
+- `mode` (`"smart"`) is the executing mode, which defines the executed action. Possible modes are:
+    + `"push"` to push the current selection as fields. This will overwrite already pushed fields.
+    + `"pop"` to pop the pushed fields as selections
+    + `"remove"` to remove the pushed fields without adding them to the selection. This has the same behavior as pop if `only_other` is `true`.
+    + `"add"` to add the current selection to the pushed fields
+    + `"subtract"` to subtract the current selection from the pushed fields
+    + `"smart"` to try to detect whether to push, pop or jump to the next field
+    + `"toggle"` to pop if fields are pushed, else push the selections as fields.
+    + `"cycle"` to push or go next. This will cycle, i.e. go to the first if the last field is reached, never pops
+- `jump_forward` (`true`) can be `true` to jump forward and `false` to jump backward
+- `only_other` (`false`) ignores the current selection for pop and go next actions.
+
+Suggestion for more keybindings based on the arguments:
+``` js
+// default use of selection_fields
+{ "keys": ["alt+d"], "command": "selection_fields" },
+// jump and remove current selection in selection_fields
+{ "keys": ["ctrl+alt+d"], "command": "selection_fields",
+  "args": {"mode": "smart", "only_other": true} },
+// cancel selection_fields and remove current selection
+{ "keys": ["ctrl+alt+shift+d"], "command": "selection_fields",
+  "args": {"mode": "toggle", "only_other": true} },
+```
+
 ## Installation
 
 Either use [Package Control](https://sublime.wbond.net/installation) and search for `MultiEditUtils` or clone this repository into Sublime Text "Packages" directory.

--- a/selection_fields.py
+++ b/selection_fields.py
@@ -1,0 +1,223 @@
+import sublime
+import sublime_plugin
+
+_ST3 = sublime.version() >= "3000"
+
+# highlight pushed region options
+if _ST3:
+    _FLAGS = sublime.DRAW_EMPTY | sublime.DRAW_NO_FILL
+else:
+    _FLAGS = sublime.DRAW_EMPTY | sublime.DRAW_OUTLINED
+
+_SCOPE = "comment"
+
+def _set_fields(view, regions):
+    """Set the fields as regions in the view."""
+    # push the fields to the view, kwargs for ST3 and pos args for ST2
+    if _ST3:
+        view.add_regions("meu_sf_stored_selections", regions, scope=_SCOPE,
+                         flags=_FLAGS)
+    else:
+        view.add_regions("meu_sf_stored_selections", regions, _SCOPE, _FLAGS)
+
+def _change_selection(view, regions, pos):
+    """Extract the next selection, push all other fields."""
+    # save and remove the position in the regions
+    sel = regions[pos]
+    del regions[pos]
+    # add the regions as fields to the view
+    _set_fields(view, regions)
+    # add a feedback to the statusbar
+    if len(regions) >= 1:
+        view.set_status("meu_field_message",
+                        "Selection-Field {0} of {1}"
+                        .format(pos + 1, len(regions) + 1))
+    else:
+        view.erase_status("meu_field_message")
+    # return the selection, which was at the position
+    sel_regions = [sel]
+    return sel_regions
+
+
+def _restore_selection(view, only_other):
+    """Restore the selection from the pushed fields."""
+    sel_regions = view.get_regions("meu_sf_stored_selections")
+    if not only_other:
+        sel_regions.extend(view.sel())
+    view.erase_regions("meu_sf_stored_selections")
+    view.erase_status("meu_field_message")
+    return sel_regions
+
+
+def _execute_jump(view, jump_forward, only_other):
+    """
+    Add the selection to the fields and move the selection to the
+    next field.
+    """
+    regions = view.get_regions("meu_sf_stored_selections")
+
+    try:
+        # search for the first field, which is behind the last selection
+        end = max(sel.end() for sel in view.sel())
+        pos = next(i for i, sel in enumerate(regions) if sel.begin() > end)
+    except:
+        # if there is no remaining field move the position behind the regions
+        pos = len(regions)
+    # insert the selection into the region
+    if only_other:
+        sel_count = 0
+    else:
+        sel_count = len(view.sel())
+        if sel_count == 1:
+            # handle special case of one selection
+            regions.insert(pos, view.sel()[0])
+        else:
+            # put the selections into the regions array
+            regions = regions[:pos] + list(view.sel()) + regions[pos:]
+    # the forward jump must jump over all added selections
+    delta = sel_count if jump_forward else -1
+    # move the position to the next field
+    pos = pos + delta
+    return regions, pos
+
+def _subtract_selection(pushed_regions, sel_regions):
+    """Subtract the selections from the pushed fields."""
+    for reg in pushed_regions:
+        for sel in sel_regions:
+            if sel.begin() <= reg.end() and reg.begin() <= sel.end():
+                # yield the region from the start of the field to the selection
+                if reg.begin() < sel.begin():
+                    yield sublime.Region(reg.begin(), sel.begin())
+                # update the region to be from the end of the selection to
+                # the end of the field
+                reg = sublime.Region(sel.end(), reg.end())
+                # if the region is not forward, break and don't add it as field
+                if not reg.a < reg.b:
+                    break
+        else:
+            # yield the region as field
+            yield reg
+
+_valid_modes = [
+    "push",  # push the current selection as fields, overwrite existing fields
+    "pop",  # pop the pushed field and add them to the selection
+    "remove",  # pop the pushed field without adding them to the selection
+               # same behavior as pop if only_other is true
+    "add",  # add the current selection to the pushed fields
+    "subtract",  # subtract the current selection from the pushed fields
+    "smart",  # try to detect whether to push, pop or go next
+    "toggle",  # pop if fields are pushed, else push
+    "cycle"  # push or go next, go to first if at the end, never pop
+]
+
+
+class SelectionFieldsCommand(sublime_plugin.TextCommand):
+    def run(self, edit, mode="smart", jump_forward=True, only_other=False):
+        if mode not in _valid_modes:
+            sublime.error_message(
+                "'{0}' is an invalid mode for 'selection_fields'.\n"
+                "Valid modes are: [{1}]"
+                .format(mode, ", ".join(_valid_modes))
+            )
+            return
+        view = self.view
+        has_regions = bool(view.get_regions("meu_sf_stored_selections"))
+        do_push = {
+            "pop": False,
+            "remove": False,
+            "push": True,
+            "subtract": False,
+            "add": False  # add is specially handled
+        }.get(mode, not has_regions)
+        # the regions, which should be selected after executing this command
+        sel_regions = None
+
+        if do_push:  # push or initial trigger with anything except pop
+            sels = list(view.sel())
+            border_pos = 0 if jump_forward else len(sels) - 1
+            sel_regions = _change_selection(view, sels, border_pos)
+        elif mode == "subtract":  # subtract selections from the pushed fields
+            sel_regions = list(view.sel())
+            pushed_regions = view.get_regions("meu_sf_stored_selections")
+            regions = list(_subtract_selection(pushed_regions, sel_regions))
+            _set_fields(view, regions)
+        elif mode == "add":  # add selections to the pushed fields
+            pushed_regions = view.get_regions("meu_sf_stored_selections")
+            sel_regions = list(view.sel())
+            _set_fields(view, sel_regions + pushed_regions)
+        elif mode == "remove":  # remove pushed fields
+            pop_regions = _restore_selection(view, only_other)
+            sel_regions = list(view.sel()) if not only_other else pop_regions
+        elif mode not in ["smart", "cycle"]:  # pop or toggle with region
+            sel_regions = _restore_selection(view, only_other)
+        else:  # smart or cycle
+            # execute the jump
+            regions, pos = _execute_jump(view, jump_forward, only_other)
+            # if we are in the cycle mode force the position to be valid
+            if mode == "cycle":
+                pos = pos % len(regions)
+            # check whether it is a valid position
+            pos_valid = pos == pos % len(regions)
+            if pos_valid:
+                # move the selection to the new field
+                sel_regions = _change_selection(view, regions, pos)
+            else:
+                # if we reached the end restore the selection and
+                # remove the highlight regions
+                sel_regions = _restore_selection(view, only_other)
+
+        # change to the result selections, if they exists
+        if sel_regions:
+            view.sel().clear()
+            if _ST3:
+                view.sel().add_all(sel_regions)
+            else:
+                for sel in sel_regions:
+                    view.sel().add(sel)
+            view.show(sel_regions[0])
+
+
+class SelectionFieldsContext(sublime_plugin.EventListener):
+    def on_query_context(self, view, key, operator, operand, match_all):
+        if key not in ["is_selection_field", "selection_fields_tab_enabled",
+                       "selection_fields_escape_enabled"]:
+            return False
+
+        if key == "is_selection_field":
+            # selection field is active if the regions are pushed to the view
+            result = bool(view.get_regions("meu_sf_stored_selections"))
+        else:
+            # the *_enabled key has the same name in the settings
+            settings = sublime.load_settings("MultiEditUtils.sublime-settings")
+            result = settings.get(key, False)
+
+        if operator == sublime.OP_EQUAL:
+            result = result == operand
+        elif operator == sublime.OP_NOT_EQUAL:
+            result = result != operand
+        else:
+            raise Exception("Invalid Operator '{0}'.".format(operator))
+        return result
+
+
+# this context listener is necessary for ST2/3 compatibility, because
+# the popup has only been added in ST3 build 3080 and we want this
+# context to be disabled for the escape key
+class MeuPopupVisibleProxyContext(sublime_plugin.EventListener):
+    def on_query_context(self, view, key, operator, operand, match_all):
+        if key != "meu_popup_visible_proxy":
+            return False
+
+        # the popup has been added in ST build 3080
+        if hasattr(view, "is_popup_visible"):
+            result = view.is_popup_visible()
+        else:
+            result = False
+
+        if operator == sublime.OP_EQUAL:
+            result = result == operand
+        elif operator == sublime.OP_NOT_EQUAL:
+            result = result != operand
+        else:
+            raise Exception("Invalid Operator '{0}'.".format(operator))
+        return result

--- a/tests/testSelectionFields.py
+++ b/tests/testSelectionFields.py
@@ -1,0 +1,182 @@
+# coding: utf8
+
+import sublime
+from unittest import TestCase
+
+_ST3 = sublime.version() >= "3000"
+version = sublime.version()
+
+
+content_string = """Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum."""
+
+
+def to_region(v):
+    if isinstance(v, int):
+        region = sublime.Region(v, v)
+    elif isinstance(v, sublime.Region):
+        region = v
+    else:
+        region = sublime.Region(v[0], v[1])
+    return region
+
+
+class TestSelectionFields(TestCase):
+    def setUp(self):
+        self.view = sublime.active_window().new_file()
+        regions = [(12, 14), (32, 30), 50, 60]
+        self.start_regions = list(map(to_region, regions))
+
+        self.view.run_command("insert", {"characters": content_string})
+        self.select_regions(self.start_regions)
+
+    def tearDown(self):
+        if self.view:
+            self.view.set_scratch(True)
+            self.view.window().run_command("close_file")
+
+    def assertSelectionEqual(self, sel1, sel2):
+        self.assertEqual(len(sel1), len(sel2))
+        for i in range(len(sel1)):
+            self.assertEqual(to_region(sel1[i]), to_region(sel2[i]))
+
+    def select_regions(self, regions):
+        self.view.sel().clear()
+        if _ST3:
+            self.view.sel().add_all(map(to_region, regions))
+        else:
+            for region in regions:
+                self.view.sel().add(to_region(region))
+
+    def test_toggle(self):
+        """Test whether the toggle works."""
+        view = self.view
+        regions = list(self.start_regions)
+
+        view.run_command("selection_fields", {"mode": "toggle"})
+
+        self.assertEqual(len(view.sel()), 1)
+        self.assertEqual(view.sel()[0], regions[0])
+        stored_regions = view.get_regions("meu_sf_stored_selections")
+        self.assertSelectionEqual(regions[1:], stored_regions)
+
+        view.run_command("selection_fields", {"mode": "toggle"})
+        self.assertEqual(len(view.sel()), len(regions))
+        self.assertSelectionEqual(view.sel(), regions)
+
+    def test_smart_run(self):
+        """Test whether a full run with the smart mode works."""
+        view = self.view
+        regions = list(self.start_regions)
+
+        view.run_command("selection_fields", {"mode": "smart"})
+
+        for i in range(len(regions)):
+            self.assertEqual(len(view.sel()), 1)
+            self.assertEqual(view.sel()[0], regions[i])
+            stored_regions = view.get_regions("meu_sf_stored_selections")
+            self.assertSelectionEqual(regions[:i] + regions[i+1:],
+                                      stored_regions)
+            view.run_command("selection_fields", {"mode": "smart"})
+        self.assertSelectionEqual(view.sel(), regions)
+
+    def test_smart_move(self):
+        """
+        Test whether moving during a run, results in the corresponding
+        caret positions after the run.
+        """
+        view = self.view
+        regions = list(self.start_regions)
+
+        view.run_command("selection_fields", {"mode": "smart"})
+
+        for i in range(len(regions)):
+            sel = view.sel()[0]
+            if sel.empty():
+                regions[i] = sel.end() + i + 1
+            else:
+                regions[i] = sel.end() + i
+            for _ in range(i + 1):
+                view.run_command("move", {"by": "characters", "forward": True})
+            view.run_command("selection_fields", {"mode": "smart"})
+        self.assertSelectionEqual(view.sel(), regions)
+
+    def test_smart_add_selections(self):
+        """
+        Test whether adding carets during a run, results in the
+        corresponding caret positions after the run.
+        """
+        view = self.view
+        regions = list(self.start_regions)
+
+        view.run_command("selection_fields", {"mode": "smart"})
+
+        for i, v in enumerate(self.start_regions):
+            sel = view.sel()[0]
+            new_sel = to_region(sel.begin() - 1)
+            view.sel().add(new_sel)
+            regions.insert(i * 2, to_region(new_sel))
+
+            view.run_command("selection_fields", {"mode": "smart"})
+        self.assertSelectionEqual(view.sel(), regions)
+
+    def test_jump_remove(self):
+        """
+        Test whether jumps remove other selections.
+        """
+        view = self.view
+
+        view.run_command("selection_fields", {"mode": "smart"})
+
+        jumps = 3
+        for _ in range(jumps):
+            view.run_command("selection_fields", {"mode": "smart"})
+        self.assertSelectionEqual(view.sel(), [self.start_regions[jumps]])
+
+    def test_add(self):
+        """
+        Test whether it is possible to add fields via the add mode.
+        """
+        view = self.view
+        regions = list(self.start_regions)
+        add_regions_list = [(16, 17), 54, 109]
+        view.run_command("selection_fields", {"mode": "add"})
+
+        view.sel().clear()
+        self.select_regions(add_regions_list)
+
+        view.run_command("selection_fields", {"mode": "add"})
+        view.run_command("move", {"by": "characters", "forward": True})
+        view.run_command("selection_fields",
+                         {"mode": "pop", "only_other": True})
+
+        # add the added regions and sort it to retrieve the desired selections
+        regions.extend(map(to_region, add_regions_list))
+        regions.sort(key=lambda sel: sel.begin())
+        self.assertSelectionEqual(view.sel(), regions)
+
+    def test_subtract(self):
+        """Test whether subtract fields works properly."""
+        view = self.view
+        regions_list = [(16, 35), 54, 60, (100, 103)]
+        subtract_regions_list = [(2, 10), (14, 20), 54, (99, 120)]
+        result_regions_list = [(20, 35), 60]
+
+        self.select_regions(regions_list)
+
+        view.run_command("selection_fields", {"mode": "add"})
+
+        self.select_regions(subtract_regions_list)
+
+        view.run_command("selection_fields", {"mode": "subtract"})
+
+        view.run_command("selection_fields",
+                         {"mode": "pop", "only_other": True})
+
+        # add the added regions and sort it to retrieve the desired selections
+        regions = list(map(to_region, result_regions_list))
+        self.assertSelectionEqual(view.sel(), regions)


### PR DESCRIPTION
This PR adds the `selection_fields` command, which turns the current selection into fields, which behave similar to the fields of snippet. This means if you press `ctrl+alt+d` all selections except the first one will be pushed as highlighting regions and you can solely modify the first one. Afterwards you can press `ctrl+alt+d` again or `tab` to move to the next fields and `shift+tab` to move to the previous field. If you have reached the last field and press `ctrl+alt+d` or `tab` all highlighting regions will be poped as selections again. While having the fields pushed you can press `escape` to cancel and pop all fields as selections.

I think it can be very useful if you have a multiple-selection and want to insert a different character (or something like this) at each selection.

Demonstration:
![selection_fields_demo](https://cloud.githubusercontent.com/assets/12573621/14141079/1852e860-f67d-11e5-8e1f-b2900acc8afe.gif)


Image for README:
![demo_selection_fields](https://cloud.githubusercontent.com/assets/12573621/14402686/17391716-fe3d-11e5-8fba-4e52a4f93459.gif)


~~This PR is _not yet ready to pull_, since I still want to add a few options/modes, tests, documentation, and have to add ST2 compatibility~~.