### PR TITLE
Improved and emphasized selection fields `add` functionality

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,6 +2,7 @@
   { "command": "jump_to_last_region", "caption" : "MultiEditUtils: Jump to last region" },
   { "command": "add_last_selection", "caption" : "MultiEditUtils: Add last selection" },
   { "command": "selection_fields", "caption": "MultiEditUtils: Selection as Fields", "args": {"mode": "toggle"} },
+  { "command": "selection_fields", "caption": "MultiEditUtils: Selection as Fields - Add Selections to Fields", "args": {"mode": "add"} },
   { "command": "cycle_through_regions", "caption" : "MultiEditUtils: Cycle through regions" },
   { "command": "normalize_region_ends", "caption" : "MultiEditUtils: Normalize region ends" },
   { "command": "split_selection", "caption" : "MultiEditUtils: Split selection" },

--- a/MultiEditUtils.sublime-settings
+++ b/MultiEditUtils.sublime-settings
@@ -2,11 +2,11 @@
   "live_split_selection" : true,
   // the highlighting scope of fields
   "selection_fields.scope.fields": "comment",
+  // the highlighting scope of fields added via the `add` mode
+  "selection_fields.scope.added_fields": "none",
   // whether the add command of selection fields should add separated field,
   // such that the special keybindings are not enabled via the add command
   "selection_fields.add_separated": true,
-  // the highlighting scope of fields added via the `add` mode
-  "selection_fields.scope.added_fields": "none",
   // whether the tab key should jump to the next field during the selection field mode
   "selection_fields_tab_enabled": true,
   // whether the escape key should cancel the selection field mode

--- a/MultiEditUtils.sublime-settings
+++ b/MultiEditUtils.sublime-settings
@@ -1,5 +1,9 @@
 {
   "live_split_selection" : true,
+  // the highlighting scope of fields
+  "selection_fields.scope.fields": "comment",
+  // the highlighting scope of fields added via the `add` mode
+  "selection_fields.scope.added_fields": "none",
   // whether the tab key should jump to the next field during the selection field mode
   "selection_fields_tab_enabled": true,
   // whether the escape key should cancel the selection field mode

--- a/MultiEditUtils.sublime-settings
+++ b/MultiEditUtils.sublime-settings
@@ -2,6 +2,9 @@
   "live_split_selection" : true,
   // the highlighting scope of fields
   "selection_fields.scope.fields": "comment",
+  // whether the add command of selection fields should add separated field,
+  // such that the special keybindings are not enabled via the add command
+  "selection_fields.add_separated": true,
   // the highlighting scope of fields added via the `add` mode
   "selection_fields.scope.added_fields": "none",
   // whether the tab key should jump to the next field during the selection field mode

--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ Arguments:
 - `only_other` (`false`) ignores the current selection for pop and go next actions.
 
 Suggestion for more keybindings based on the arguments:
+
 ``` js
 // default use of selection_fields
 { "keys": ["alt+d"], "command": "selection_fields" },
+// add the current selections as a fields
+{ "keys": ["alt+a"], "command": "selection_fields", "args": {"mode": "add"} },
 // jump and remove current selection in selection_fields
 { "keys": ["ctrl+alt+d"], "command": "selection_fields",
   "args": {"mode": "smart", "only_other": true} },

--- a/selection_fields.py
+++ b/selection_fields.py
@@ -11,14 +11,31 @@ else:
 
 _SCOPE = "comment"
 
-def _set_fields(view, regions):
+
+def _set_fields(view, regions, added_fields=False):
     """Set the fields as regions in the view."""
     # push the fields to the view, kwargs for ST3 and pos args for ST2
+    reg_name = ("meu_sf_stored_selections" if not added_fields
+                else "meu_sf_added_selections")
     if _ST3:
-        view.add_regions("meu_sf_stored_selections", regions, scope=_SCOPE,
+        view.add_regions(reg_name, regions, scope=_SCOPE,
                          flags=_FLAGS)
     else:
-        view.add_regions("meu_sf_stored_selections", regions, _SCOPE, _FLAGS)
+        view.add_regions(reg_name, regions, _SCOPE, _FLAGS)
+
+
+def _get_fields(view, added_fields=True):
+    fields = view.get_regions("meu_sf_stored_selections")
+    if added_fields:
+        fields.extend(view.get_regions("meu_sf_added_selections"))
+    return fields
+
+
+def _erase_fields(view):
+    view.erase_regions("meu_sf_stored_selections")
+    view.erase_regions("meu_sf_added_selections")
+    view.erase_status("meu_field_message")
+
 
 def _change_selection(view, regions, pos):
     """Extract the next selection, push all other fields."""
@@ -41,11 +58,10 @@ def _change_selection(view, regions, pos):
 
 def _restore_selection(view, only_other):
     """Restore the selection from the pushed fields."""
-    sel_regions = view.get_regions("meu_sf_stored_selections")
+    sel_regions = _get_fields(view)
     if not only_other:
         sel_regions.extend(view.sel())
-    view.erase_regions("meu_sf_stored_selections")
-    view.erase_status("meu_field_message")
+    _erase_fields(view)
     return sel_regions
 
 
@@ -54,7 +70,7 @@ def _execute_jump(view, jump_forward, only_other):
     Add the selection to the fields and move the selection to the
     next field.
     """
-    regions = view.get_regions("meu_sf_stored_selections")
+    regions = _get_fields(view)
 
     try:
         # search for the first field, which is behind the last selection
@@ -79,6 +95,7 @@ def _execute_jump(view, jump_forward, only_other):
     # move the position to the next field
     pos = pos + delta
     return regions, pos
+
 
 def _subtract_selection(pushed_regions, sel_regions):
     """Subtract the selections from the pushed fields."""
@@ -121,14 +138,15 @@ class SelectionFieldsCommand(sublime_plugin.TextCommand):
             )
             return
         view = self.view
-        has_regions = bool(view.get_regions("meu_sf_stored_selections"))
+        has_fields = bool(_get_fields(view))
+        has_only_added_fields = not _get_fields(view, added_fields=False)
         do_push = {
             "pop": False,
             "remove": False,
             "push": True,
             "subtract": False,
             "add": False  # add is specially handled
-        }.get(mode, not has_regions)
+        }.get(mode, not has_fields)
         # the regions, which should be selected after executing this command
         sel_regions = None
 
@@ -138,17 +156,21 @@ class SelectionFieldsCommand(sublime_plugin.TextCommand):
             sel_regions = _change_selection(view, sels, border_pos)
         elif mode == "subtract":  # subtract selections from the pushed fields
             sel_regions = list(view.sel())
-            pushed_regions = view.get_regions("meu_sf_stored_selections")
+            pushed_regions = _get_fields(view)
             regions = list(_subtract_selection(pushed_regions, sel_regions))
             _set_fields(view, regions)
         elif mode == "add":  # add selections to the pushed fields
-            pushed_regions = view.get_regions("meu_sf_stored_selections")
+            pushed_regions = _get_fields(view)
             sel_regions = list(view.sel())
-            _set_fields(view, sel_regions + pushed_regions)
+            _set_fields(view, sel_regions + pushed_regions,
+                        added_fields=has_only_added_fields)
         elif mode == "remove":  # remove pushed fields
             pop_regions = _restore_selection(view, only_other)
             sel_regions = list(view.sel()) if not only_other else pop_regions
         elif mode not in ["smart", "cycle"]:  # pop or toggle with region
+            sel_regions = _restore_selection(view, only_other)
+        # pop added fields instead of jumping
+        elif mode == "smart" and has_only_added_fields:
             sel_regions = _restore_selection(view, only_other)
         else:  # smart or cycle
             # execute the jump
@@ -179,13 +201,18 @@ class SelectionFieldsCommand(sublime_plugin.TextCommand):
 
 class SelectionFieldsContext(sublime_plugin.EventListener):
     def on_query_context(self, view, key, operator, operand, match_all):
-        if key not in ["is_selection_field", "selection_fields_tab_enabled",
+        if key not in ["is_selection_field", "is_selection_field.added_fields",
+                       "selection_fields_tab_enabled",
                        "selection_fields_escape_enabled"]:
             return False
 
         if key == "is_selection_field":
             # selection field is active if the regions are pushed to the view
-            result = bool(view.get_regions("meu_sf_stored_selections"))
+            result = bool(_get_fields(view, added_fields=False))
+        elif key == "is_selection_field.added_fields":
+            # selection field is active if the regions are pushed to the view
+            # also if added fields are pushed
+            result = bool(_get_fields(view))
         else:
             # the *_enabled key has the same name in the settings
             settings = sublime.load_settings("MultiEditUtils.sublime-settings")

--- a/selection_fields.py
+++ b/selection_fields.py
@@ -157,7 +157,8 @@ class SelectionFieldsCommand(sublime_plugin.TextCommand):
             return
         view = self.view
         has_fields = bool(_get_fields(view))
-        has_only_added_fields = not _get_fields(view, added_fields=False)
+        has_only_added_fields = (not _get_fields(view, added_fields=False) and
+                                 _get_settings("add_separated", True))
         do_push = {
             "pop": False,
             "remove": False,

--- a/selection_fields.py
+++ b/selection_fields.py
@@ -9,8 +9,6 @@ if _ST3:
 else:
     _FLAGS = sublime.DRAW_EMPTY | sublime.DRAW_OUTLINED
 
-_SCOPE = "comment"
-
 
 def get_settings(key, default=None):
     """Get the setting specified by the key."""
@@ -47,6 +45,10 @@ def _get_fields(view, added_fields=True):
     if added_fields:
         fields.extend(view.get_regions("meu_sf_added_selections"))
     return fields
+
+
+def _erase_added_fields(view):
+    view.erase_regions("meu_sf_added_selections")
 
 
 def _erase_fields(view):
@@ -177,7 +179,8 @@ class SelectionFieldsCommand(sublime_plugin.TextCommand):
             sel_regions = list(view.sel())
             pushed_regions = _get_fields(view)
             regions = list(_subtract_selection(pushed_regions, sel_regions))
-            _set_fields(view, regions)
+            _erase_added_fields(view)
+            _set_fields(view, regions, added_fields=has_only_added_fields)
         elif mode == "add":  # add selections to the pushed fields
             pushed_regions = _get_fields(view)
             sel_regions = list(view.sel())


### PR DESCRIPTION
I want to emphasize the `add` functionality of selection fields, because I often use and like this mode. However I felt it was sometimes unintuitive, because adding fields enabled the `tab` and `escape` keys. Therefore I also improved it to add fields into an other highlighting region, if no fields are present.

Example usage of add:

![demo](https://cloud.githubusercontent.com/assets/12573621/15036977/b1df51b4-1296-11e6-9ba2-2cbdb20127af.gif)
